### PR TITLE
Landing Page

### DIFF
--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -33,13 +33,14 @@ jobs:
     - name: Build with Maven
       run: mvn -B package --file pom.xml
 
-    - name: Figure out which directory I'm in
-      run: echo ${{github.token}}
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: rezz-app
+        path: target
 
-    - name: Create a downloads dir
-      run: ls -al && cat settings.xml
 
-    - name: Publish to GitHub Packages Apache Maven
-      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
+#    - name: Publish to GitHub Packages Apache Maven
+#      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+#      env:
+#        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -20,10 +20,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Ready the Database
       run: ./readyDevEnv.sh
-    - name: Set up JDK 11
+    - name: Set up JDK 19
       uses: actions/setup-java@v3
       with:
-        java-version: '17'
+        java-version: '19'
         distribution: 'temurin'
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - master
+  push:
+    branches:
+      - master
 
 jobs:
   build:
@@ -37,7 +40,7 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: rezz-app-${{ date }}
+        name: rezz-app
         path: artifacts
 
 

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -32,12 +32,13 @@ jobs:
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml
-
+    - name: Create a temp folder
+      run: mkdir artifacts && cp -v target/*.jar artifacts/
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
         name: rezz-app
-        path: target
+        path: artifacts
 
 
 #    - name: Publish to GitHub Packages Apache Maven

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -33,6 +33,9 @@ jobs:
 
     - name: Figure out which directory I'm in
       run: pwd
+    - name: Create a downloads dir
+      run: mkdir downloads && ls -al
+
     #- name: Publish to GitHub Packages Apache Maven
     #  run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
     #  env:

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - master
+  push:
+    branches:
+      - master
 
 jobs:
   build:
@@ -32,12 +35,12 @@ jobs:
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml
-    - name: Create a temp folder
+    - name: Create an artifacts folder
       run: mkdir artifacts && cp -v target/*.jar artifacts/
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: rezz-app
+        name: rezz-app-${{ date }}
         path: artifacts
 
 

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -34,7 +34,7 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Figure out which directory I'm in
-      run: pwd && echo $GITHUB_WORKSPACE
+      run: echo ${{github.token}}
 
     - name: Create a downloads dir
       run: ls -al && cat settings.xml

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -31,6 +31,8 @@ jobs:
     - name: Build with Maven
       run: mvn -B package --file pom.xml
 
+    - name: Figure out which directory I'm in
+      run: pwd
     #- name: Publish to GitHub Packages Apache Maven
     #  run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
     #  env:

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Create a temp folder
       run: mkdir artifacts && cp -v target/*.jar artifacts/
     - name: Upload artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: rezz-app
         path: artifacts

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     branches:
       - master
-  push:
-    branches:
-      - master
 
 jobs:
   build:

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -20,6 +20,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Ready the Database
       run: ./readyDevEnv.sh
+    - name: Set the version
+      run: ./increment_version.sh
     - name: Set up JDK 19
       uses: actions/setup-java@v3
       with:
@@ -32,11 +34,12 @@ jobs:
       run: mvn -B package --file pom.xml
 
     - name: Figure out which directory I'm in
-      run: pwd
-    - name: Create a downloads dir
-      run: mkdir downloads && ls -al
+      run: pwd && echo $GITHUB_WORKSPACE
 
-    #- name: Publish to GitHub Packages Apache Maven
-    #  run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
-    #  env:
-    #    GITHUB_TOKEN: ${{ github.token }}
+    - name: Create a downloads dir
+      run: ls -al && cat settings.xml
+
+    - name: Publish to GitHub Packages Apache Maven
+      run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml
+      env:
+        GITHUB_TOKEN: ${{ github.token }}

--- a/increment_version.sh
+++ b/increment_version.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+date_tag=$(date +"%Y-%m-%d".1)
+sed -i '' "s/0.0.1-SNAPSHOT/$date_tag/" pom.xml

--- a/increment_version.sh
+++ b/increment_version.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 date_tag=$(date +"%Y-%m-%d".1)
-sed -i '' "s/0.0.1-SNAPSHOT/$date_tag/" pom.xml
+# For mac
+# sed -i '' "s/0.0.1-SNAPSHOT/$date_tag/" pom.xml
+# For everywhere else
+sed -i "s/0.0.1-SNAPSHOT/$date_tag/" pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <name>rezz</name>
     <description>rezz</description>
     <properties>
-        <java.version>17</java.version>
+        <java.version>19</java.version>
         <spring.version>6.0.2</spring.version>
         <springboot.version>3.0.0</springboot.version>
     </properties>
@@ -77,11 +77,8 @@
             <version>2.3.31</version>
         </dependency>
         -->
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context-support</artifactId>
-            <version>${spring.version}</version>
-        </dependency>
+
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <version>3.0.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
-    <groupId>com.example</groupId>
+    <groupId>com.application.rezz</groupId>
     <artifactId>rezz</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>rezz</name>

--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,25 @@
     <properties>
         <java.version>17</java.version>
         <spring.version>6.0.2</spring.version>
+        <springboot.version>3.0.0</springboot.version>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+            <version>${springboot.version}</version>
+            <!--added for security vulnerability avoidance -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jdbc</artifactId>
+            <version>${springboot.version}</version>
         </dependency>
         <dependency>
             <groupId>com.mysql</groupId>
@@ -56,11 +70,13 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
             <version>2.3.31</version>
         </dependency>
+        -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context-support</artifactId>

--- a/src/main/java/com/application/rezz/Greeting.java
+++ b/src/main/java/com/application/rezz/Greeting.java
@@ -1,0 +1,22 @@
+package com.application.rezz;
+
+public class Greeting {
+    private long id;
+    private String content;
+
+    public long getId() {
+        return id;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/application/rezz/LandingPageController.java
+++ b/src/main/java/com/application/rezz/LandingPageController.java
@@ -1,0 +1,23 @@
+package com.application.rezz;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Controller
+public class LandingPageController {
+    @GetMapping("/hi")
+    public String greeting(Model model) {
+        model.addAttribute("shit", "Dumbass");
+        model.addAttribute("greeting", new Greeting());
+        return "home";
+    }
+
+    @PostMapping("/hi")
+    public String greetingSubmit(@ModelAttribute Greeting greeting, Model model) {
+        model.addAttribute("greeting", greeting);
+        return "result";
+    }
+}

--- a/src/main/java/com/application/rezz/RezzApplication.java
+++ b/src/main/java/com/application/rezz/RezzApplication.java
@@ -1,4 +1,4 @@
-package com.example.rezz;
+package com.application.rezz;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/src/main/java/com/application/rezz/RezzApplication.java
+++ b/src/main/java/com/application/rezz/RezzApplication.java
@@ -1,13 +1,26 @@
 package com.application.rezz;
 
+import lombok.extern.log4j.Log4j2;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.env.Environment;
 
 @SpringBootApplication
+@Log4j2
 public class RezzApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(RezzApplication.class, args);
+    }
+
+    @Bean
+    ApplicationRunner applicationRunner(Environment environment) {
+        ApplicationRunner runner = args -> {};
+        String[] profiles = environment.getActiveProfiles();
+        log.info("Active Profiles {}", profiles);
+        return runner;
     }
 
 }

--- a/src/main/java/com/application/rezz/RezzApplication.java
+++ b/src/main/java/com/application/rezz/RezzApplication.java
@@ -1,11 +1,13 @@
 package com.application.rezz;
 
+
 import lombok.extern.log4j.Log4j2;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.env.Environment;
+
 
 @SpringBootApplication
 @Log4j2

--- a/src/main/java/com/application/rezz/controllers/LandingPageController.java
+++ b/src/main/java/com/application/rezz/controllers/LandingPageController.java
@@ -1,5 +1,6 @@
-package com.application.rezz;
+package com.application.rezz.controllers;
 
+import com.application.rezz.Greeting;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,13 @@
+spring.datasource.username=springuser
+spring.datasource.password=reservation
+spring.datasource.url=jdbc:mysql://localhost:3306/reservations_db
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.sql.init.mode=always
+spring.sql.init.platform=mysql
+#spring.datasource.dbcp2.default-schema=schema-sql.sql
+spring.jpa.show-sql=true
+
+
+# when DB is not ready - just disable this bean
+#spring.autoconfigure.exclude= \
+#  org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -4,10 +4,9 @@ spring.datasource.url=jdbc:mysql://localhost:3306/reservations_db
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.sql.init.mode=always
 spring.sql.init.platform=mysql
-#spring.datasource.dbcp2.default-schema=schema-sql.sql
 spring.jpa.show-sql=true
 
 
-# when DB is not ready - just disable this bean
+# if DB is not ready - just disable this bean
 #spring.autoconfigure.exclude= \
 #  org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,4 @@
-spring.datasource.username=springuser
-spring.datasource.password=reservation
-spring.datasource.url=jdbc:mysql://localhost:3306/reservations_db
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.sql.init.mode=always
-spring.sql.init.platform=mysql
-#spring.datasource.dbcp2.default-schema=schema-sql.sql
-spring.jpa.show-sql=true
-
-# when DB is not ready - just disable this bean
-#spring.autoconfigure.exclude= \
-#  org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+spring.profiles.active=dev
+spring.thymeleaf.cache=false
+spring.thymeleaf.enabled=true
+spring.thymeleaf.check-template=true

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Welcome to Rezz</title>
+    <link href="/styles/main.css" rel="stylesheet"/>
+    <script src="/js/main.js"></script>
 </head>
 <body>
   <p>Test <a href="/hi">this</a></p>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Welcome to Rezz</title>
+</head>
+<body>
+  <p>Test <a href="/hi">this</a></p>
+</body>
+</html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <title>Welcome to Rezz</title>

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -1,0 +1,1 @@
+console.log("JavaScript loaded");

--- a/src/main/resources/static/styles/main.css
+++ b/src/main/resources/static/styles/main.css
@@ -1,0 +1,3 @@
+body {
+    background: aqua;
+}

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Homepage</title>
+    <link th:href="@{/styles/main.css}" rel="stylesheet"/>
+    <script type="text/javascript" th:src="@{/js/main.js}"></script>
 </head>
 <body>
     <p th:text="'Fuck you ' + ${shit}"/>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Homepage</title>
+</head>
+<body>
+    <p th:text="'Fuck you ' + ${shit}"/>
+
+    <form action="#" th:action="@{/hi}" th:object="${greeting}" method="post">
+        <p>Id: <input type="text" th:field="*{id}" /></p>
+        <p>MESSAGE: <input type="text" th:field="*{content}" /></p>
+        <p><input type="submit" value="Submit"/><input type="reset" value="Reset"/></p>
+    </form>
+</body>
+</html>

--- a/src/main/resources/templates/result.html
+++ b/src/main/resources/templates/result.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <title>Greeting Result</title>
+    <link th:href="@{/styles/main.css}" rel="stylesheet"/>
+    <script type="text/javascript" th:src="@{/js/main.js}"></script>
 </head>
 <body>
   <p th:text="'id: ' + ${greeting.id}" />

--- a/src/main/resources/templates/result.html
+++ b/src/main/resources/templates/result.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Greeting Result</title>
+</head>
+<body>
+  <p th:text="'id: ' + ${greeting.id}" />
+  <p th:text="'content: ' + ${greeting.content}"/>
+  <a href="/hi">Submit another greeting</a>
+</body>
+</html>

--- a/src/test/java/com/application/rezz/RezzApplicationTests.java
+++ b/src/test/java/com/application/rezz/RezzApplicationTests.java
@@ -1,13 +1,21 @@
 package com.application.rezz;
 
+import com.application.rezz.controllers.LandingPageController;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class RezzApplicationTests {
 
+    @Autowired
+    private LandingPageController landingPageController;
+
     @Test
     void contextLoads() {
+        assertThat(landingPageController).isNotNull();
     }
 
 }

--- a/src/test/java/com/application/rezz/RezzApplicationTests.java
+++ b/src/test/java/com/application/rezz/RezzApplicationTests.java
@@ -1,4 +1,4 @@
-package com.example.rezz;
+package com.application.rezz;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/com/application/rezz/controllers/LandingPageControllerTests.java
+++ b/src/test/java/com/application/rezz/controllers/LandingPageControllerTests.java
@@ -1,0 +1,25 @@
+package com.application.rezz.controllers;
+
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class LandingPageControllerTests {
+    @Value(value="${local.server.port}")
+    private int port;
+
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+
+    @Test
+    public void testHiFunctionality() throws Exception {
+        assertThat(this.testRestTemplate.getForObject("http://localhost:" + port, String.class).contains("this"));
+    }
+
+}


### PR DESCRIPTION
# Summary
This PR will add profile configuration, a landing page and controller update

# Things of Note Regarding Maven
```
org.primefaces.themes:bootstrap:pom:1.0.10 failed to transfer from http://0.0.0.0/ during a previous attempt. This failure was cached in the local repository and resolution is not reattempted until the update interval of maven-default-http-blocker has elapsed or updates are forced. Original error: Could not transfer artifact org.primefaces.themes:bootstrap:pom:1.0.10 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [prime-repo (http://repository.primefaces.org, default, releases+snapshots)]

Since Maven 3.8.1 http repositories are blocked.

Possible solutions:
- Check that Maven settings.xml does not contain http repositories
- Check that Maven pom files do not contain http repository http://repository.primefaces.org
- Add a mirror(s) for http://repository.primefaces.org that allows http url in the Maven settings.xml
- Downgrade Maven to version 3.8.1 or earlier in settings
```